### PR TITLE
Fix content caching across requests

### DIFF
--- a/site/content/cacheFeedImage.tsx
+++ b/site/content/cacheFeedImage.tsx
@@ -2,6 +2,7 @@ import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoint
 
 import { list, put } from '@vercel/blob';
 import invariant from 'invariant';
+import { unstable_cache } from 'next/cache';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import openGraph from 'open-graph-scraper';
@@ -11,58 +12,60 @@ const EMPTY_CONTENT_MARKER = 'no-content.json';
 /**
  * Cache the preview image for the given feed item on the server/CDN.
  */
-export default async function cacheFeedImage(
-  page: PageObjectResponse,
-): Promise<string | null> {
-  const imageKey = createHash('sha256')
-    .update(page.id + '-' + page.last_edited_time)
-    .digest('hex')
-    .slice(0, 16);
-  const cachePrefix = 'feed_v2/' + imageKey;
+const cacheFeedImage = unstable_cache(
+  async (page: PageObjectResponse): Promise<string | null> => {
+    const imageKey = createHash('sha256')
+      .update(page.id + '-' + page.last_edited_time)
+      .digest('hex')
+      .slice(0, 16);
+    const cachePrefix = 'feed_v2/' + imageKey;
 
-  // Check for existing blob
-  const {
-    blobs: [cachedImage],
-  } = await list({ prefix: cachePrefix });
+    // Check for existing blob
+    const {
+      blobs: [cachedImage],
+    } = await list({ prefix: cachePrefix });
 
-  if (cachedImage != null) {
-    return path.basename(cachedImage.pathname) !== EMPTY_CONTENT_MARKER
-      ? cachedImage.url
-      : null;
-  }
+    if (cachedImage != null) {
+      return path.basename(cachedImage.pathname) !== EMPTY_CONTENT_MARKER
+        ? cachedImage.url
+        : null;
+    }
 
-  let sourceImageUrl = await resolveFeedItemPreview(page);
-  if (sourceImageUrl == null) {
-    await put(cachePrefix + '/' + EMPTY_CONTENT_MARKER, '{}', {
-      access: 'public',
-      addRandomSuffix: false,
-    });
-    return null;
-  }
+    let sourceImageUrl = await resolveFeedItemPreview(page);
+    if (sourceImageUrl == null) {
+      await put(cachePrefix + '/' + EMPTY_CONTENT_MARKER, '{}', {
+        access: 'public',
+        addRandomSuffix: false,
+      });
+      return null;
+    }
 
-  // Fetch remote image
-  const response = await fetch(sourceImageUrl, { cache: 'no-store' });
-  if (!response.ok) {
-    console.warn('Failed to fetch image:', sourceImageUrl);
-    return null;
-  }
+    // Fetch remote image
+    const response = await fetch(sourceImageUrl, { cache: 'no-store' });
+    if (!response.ok) {
+      console.warn('Failed to fetch image:', sourceImageUrl);
+      return null;
+    }
 
-  const cachePath =
-    cachePrefix + '/preview' + path.extname(new URL(sourceImageUrl).pathname);
+    const cachePath =
+      cachePrefix + '/preview' + path.extname(new URL(sourceImageUrl).pathname);
 
-  try {
-    // Upload to Vercel Blob
-    const result = await put(cachePath, response.body!, {
-      access: 'public',
-      addRandomSuffix: false,
-    });
+    try {
+      // Upload to Vercel Blob
+      const result = await put(cachePath, response.body!, {
+        access: 'public',
+        addRandomSuffix: false,
+      });
 
-    return result.url;
-  } catch (e) {
-    console.error('Failed to process image:', e);
-    return null;
-  }
-}
+      return result.url;
+    } catch (e) {
+      console.error('Failed to process image:', e);
+      return null;
+    }
+  },
+);
+
+export default cacheFeedImage;
 
 async function resolveFeedItemPreview(
   page: PageObjectResponse,

--- a/site/content/getFeed.tsx
+++ b/site/content/getFeed.tsx
@@ -4,11 +4,12 @@ import type { FeedItem } from './types';
 
 import { isFullPage } from '@notionhq/client';
 import invariant from 'invariant';
-import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
 import cacheFeedImage from './cacheFeedImage';
 import { notion, richTextToPlain } from './notion';
 
 const FEED_DATABASE_ID = '341919861c8447ea8a6ae36b0ad8c730';
+const CACHE_DURATION = 60 * 5; // 5 minutes
 
 const NONEMPTY_FILTER = {
   is_not_empty: true as true,
@@ -19,7 +20,7 @@ type Options = Readonly<{
   pageSize?: number;
 }>;
 
-const getFeed = cache(
+const getFeed = unstable_cache(
   async ({ startCursor, pageSize = 10 }: Options = {}): Promise<
     Array<FeedItem>
   > => {
@@ -104,6 +105,10 @@ const getFeed = cache(
     }
 
     return Promise.all(itemPromises);
+  },
+  [],
+  {
+    revalidate: CACHE_DURATION,
   },
 );
 

--- a/site/content/getProperties.tsx
+++ b/site/content/getProperties.tsx
@@ -2,39 +2,46 @@
 
 import { isFullPage } from '@notionhq/client';
 import invariant from 'invariant';
-import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
 import { notion } from './notion';
 
 const PROPERTIES_DATABASE_ID = '57bb578c629a411695fb9df41600b0af';
+const CACHE_DURATION = 60 * 5; // 5 minutes
 
-const getProperties = cache(async (): Promise<Record<string, string>> => {
-  const response = await notion.databases.query({
-    database_id: PROPERTIES_DATABASE_ID,
-  });
-  const properties: Record<string, string> = {};
+const getProperties = unstable_cache(
+  async (): Promise<Record<string, string>> => {
+    const response = await notion.databases.query({
+      database_id: PROPERTIES_DATABASE_ID,
+    });
+    const properties: Record<string, string> = {};
 
-  for (const page of response.results) {
-    if (!isFullPage(page)) {
-      continue;
+    for (const page of response.results) {
+      if (!isFullPage(page)) {
+        continue;
+      }
+
+      invariant(
+        page.properties['Key']?.type === 'title',
+        'Expected property "Key" to be of type "title"',
+      );
+      invariant(
+        page.properties['Value']?.type === 'rich_text',
+        'Expected property "Value" to be of type "rich_text"',
+      );
+
+      const key = page.properties['Key'].title[0].plain_text;
+
+      if (key != null) {
+        properties[key] = page.properties['Value'].rich_text[0].plain_text;
+      }
     }
 
-    invariant(
-      page.properties['Key']?.type === 'title',
-      'Expected property "Key" to be of type "title"',
-    );
-    invariant(
-      page.properties['Value']?.type === 'rich_text',
-      'Expected property "Value" to be of type "rich_text"',
-    );
-
-    const key = page.properties['Key'].title[0].plain_text;
-
-    if (key != null) {
-      properties[key] = page.properties['Value'].rich_text[0].plain_text;
-    }
-  }
-
-  return properties;
-});
+    return properties;
+  },
+  [],
+  {
+    revalidate: CACHE_DURATION,
+  },
+);
 
 export default getProperties;


### PR DESCRIPTION
Turns out that React's `cache` is per-request in Next.js and Next's `unstable_cache` is across multiple requests(!).

i.e. Fix my site after exceeding Vercel Blob's "Advanced Operations" limit.